### PR TITLE
feat: make layer compatible with scarthgap

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "murata-wireless"
 BBFILE_PATTERN_murata-wireless = "^${LAYERDIR}/"
 BBFILE_PRIORITY_murata-wireless = "9"
 
-LAYERSERIES_COMPAT_murata-wireless = "nanbield"
+LAYERSERIES_COMPAT_murata-wireless = "nanbield scarthgap"
 
 # NOTE: Added to remove the error, "A native program mkfs.ext4 required to build the image was not found".
 IMAGE_FSTYPES += "ext4 wic.bz2"


### PR DESCRIPTION
The setting in layer.conf seems to be sufficient for a successful build. We need to use this branch as the upstream scarthgap branch lacks support for the cypress chips.

[NEEXT-9956]